### PR TITLE
Add Yahoo and Facebook login

### DIFF
--- a/template.sample.yaml
+++ b/template.sample.yaml
@@ -529,14 +529,6 @@ Resources:
         Yahoo LoginのコールバックURLを指定
       Type: String
       Value: xxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-  YahooExternalProviderLoginCommonTempPassword:
-    Type: "AWS::SSM::Parameter"
-    Properties:
-      Name: !Sub "${AWS::StackName}YahooExternalProviderLoginCommonTempPassword"
-      Description: |
-        外部サービス認証に使う共通の一時パスワードを指定。各環境で独自に生成してください
-      Type: String
-      Value: xxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
   #
   # Front end

--- a/template.sample.yaml
+++ b/template.sample.yaml
@@ -401,6 +401,12 @@ Resources:
       Name: !Sub "${AWS::StackName}UserFirstExperienceTableName"
       Type: String
       Value: xxxxxdatabase-UserFirstExperience-1XZRHGK7SFVYY
+  NonceTableName:
+    Type: "AWS::SSM::Parameter"
+    Properties:
+      Name: !Sub "${AWS::StackName}NonceTableName"
+      Type: String
+      Value: xxxxxdatabase-Nonce-TEST456RF65H
 
   #
   # ElasticSearch
@@ -495,6 +501,42 @@ Resources:
       Type: String
       Value: xxxxxxxxxxxxxxxxxxxxxxxxxxxxx
     DependsOn: ExternalProviderLoginMark
+
+  #
+  # Yahoo Oauth
+  #
+  YahooClientId:
+    Type: "AWS::SSM::Parameter"
+    Properties:
+      Name: !Sub "${AWS::StackName}YahooClientId"
+      Description: |
+        Yahoo API用のClientIdを指定
+      Type: String
+      Value: xxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+  YahooSecret:
+    Type: "AWS::SSM::Parameter"
+    Properties:
+      Name: !Sub "${AWS::StackName}YahooSecret"
+      Description: |
+        Yahoo API用のSecretを指定
+      Type: String
+      Value: xxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+  YahooOauthCallbackUrl:
+    Type: "AWS::SSM::Parameter"
+    Properties:
+      Name: !Sub "${AWS::StackName}YahooOauthCallbackUrl"
+      Description: |
+        Yahoo LoginのコールバックURLを指定
+      Type: String
+      Value: xxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+  YahooExternalProviderLoginCommonTempPassword:
+    Type: "AWS::SSM::Parameter"
+    Properties:
+      Name: !Sub "${AWS::StackName}YahooExternalProviderLoginCommonTempPassword"
+      Description: |
+        外部サービス認証に使う共通の一時パスワードを指定。各環境で独自に生成してください
+      Type: String
+      Value: xxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
   #
   # Front end

--- a/template.sample.yaml
+++ b/template.sample.yaml
@@ -588,13 +588,13 @@ Resources:
 
   #
   # Rest API
-  # AWS API GatewayのArnのPrefix
+  # AWS API GatewayのArn
   #
-  RestApi:
+  RestApiArn:
     Type: "AWS::SSM::Parameter"
     Properties:
-      Name: !Sub "${AWS::StackName}RestApi"
+      Name: !Sub "${AWS::StackName}RestApiArn"
       Description: |
-        API GatewayのIDのPrefix
+        API GatewayのArn
       Type: String
       Value: !Sub arn:aws:execute-api:${AWS::Region}:xxxxxxxxxxxxxxxx

--- a/template.sample.yaml
+++ b/template.sample.yaml
@@ -585,3 +585,16 @@ Resources:
   # batch
   # FYI: batchリポジトリのSSMパラメータのみ、batchリポジトリ自身が保持しているのでそちらを参照
   #
+
+  #
+  # Rest API
+  # AWS API GatewayのArnのPrefix
+  #
+  RestApi:
+    Type: "AWS::SSM::Parameter"
+    Properties:
+      Name: !Sub "${AWS::StackName}RestApi"
+      Description: |
+        API GatewayのIDのPrefix
+      Type: String
+      Value: !Sub arn:aws:execute-api:${AWS::Region}:xxxxxxxxxxxxxxxx

--- a/template.sample.yaml
+++ b/template.sample.yaml
@@ -557,6 +557,14 @@ Resources:
         Facebook LoginのコールバックURLを指定
       Type: String
       Value: xxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+  FacebookAppToken:
+    Type: "AWS::SSM::Parameter"
+    Properties:
+      Name: !Sub "${AWS::StackName}FacebookAppToken"
+      Description: |
+        https://developers.facebook.com/tools/accesstoken/　から取得するApp Tokenを指定
+      Type: String
+      Value: xxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
   #
   # Front end

--- a/template.sample.yaml
+++ b/template.sample.yaml
@@ -531,6 +531,34 @@ Resources:
       Value: xxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
   #
+  # Facebook Oauth
+  #
+  FacebookAppId:
+    Type: "AWS::SSM::Parameter"
+    Properties:
+      Name: !Sub "${AWS::StackName}FacebookAppId"
+      Description: |
+        Facebook API用のAppIdを指定
+      Type: String
+      Value: xxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+  FacebookAppSecret:
+    Type: "AWS::SSM::Parameter"
+    Properties:
+      Name: !Sub "${AWS::StackName}FacebookAppSecret"
+      Description: |
+        Facebook API用のAppSecretを指定
+      Type: String
+      Value: xxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+  FacebookOauthCallbackUrl:
+    Type: "AWS::SSM::Parameter"
+    Properties:
+      Name: !Sub "${AWS::StackName}FacebookOauthCallbackUrl"
+      Description: |
+        Facebook LoginのコールバックURLを指定
+      Type: String
+      Value: xxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
+  #
   # Front end
   # TODO: ALIS-953
   #


### PR DESCRIPTION
Yahoo及びfacebookログインの実装でSSM及び環境変数の値を追加しました。

| Resource名 | Valueに入れる値 |
----|----
NonceTableName | Nonceテーブルのテーブル名 |
YahooClientId |yahooのクライアントID|
YahooSecret |yahooのシークレットID|
YahooOauthCallbackUrl |Yahooの認証時にコールバックさせたいURL|
FacebookAppId | facebookのクライアントID | 
FacebookAppSecret | facebookのシークレットID |
FacebookOauthCallbackUrl |facebookの認証時にコールバックさせたいURL|
FacebookAppToken |https://developers.facebook.com/tools/accesstoken/ から取得するApp Tokenを指定|
RestApi |API GatewayのarnのPrefixを指定|